### PR TITLE
chore: update check for active service

### DIFF
--- a/lib/browser.sh
+++ b/lib/browser.sh
@@ -32,7 +32,8 @@ open_frontend_when_ready() {
   if declare -p COMPOSE_ARGS >/dev/null 2>&1; then compose_extra=( "${COMPOSE_ARGS[@]}" ); fi
   log_info "Waiting for 'frontend' service to be running..."
   local waited_running=0
-  while ! docker_compose "${compose_extra[@]}" ps frontend 2>/dev/null | grep -q "running"; do
+  # Compose V2 shows "Up", V1 shows "Up"/"Up XX" and sometimes "running" — handle both.
+  while ! docker_compose "${compose_extra[@]}" ps frontend 2>/dev/null | grep -Eiq "\\b(Up|running)\\b"; do
     sleep 2; waited_running=$((waited_running + 2))
     if [[ $waited_running -ge $max_wait ]]; then log_warn "'frontend' not detected as running after ${max_wait}s; attempting to open anyway."; break; fi
     if [[ $((waited_running % 10)) -eq 0 ]]; then log_info "Still waiting for 'frontend'... (${waited_running}s elapsed)"; fi
@@ -49,4 +50,3 @@ open_frontend_when_ready() {
   log_info "Opening frontend at: $url"
   open_url "$url"
 }
-


### PR DESCRIPTION
Updates checks for the running docker-compose or docker compose command (support for Compose v1 and v2).

This pull request updates the logic for detecting when the `frontend` service is running in the `open_frontend_when_ready` function. The main improvement is to make the readiness check compatible with both Docker Compose V1 and V2 by matching both "Up" and "running" statuses.

**Service readiness detection improvements:**

* Updated the `docker_compose ... ps frontend` status check to match both "Up" (used by Compose V2) and "running" (used by Compose V1), ensuring the script works reliably across different Docker Compose versions.