### PR TITLE
feat(adb): add Android Debug Bridge module (multi-device safe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project uses Keep a Changelog style and aims to follow Semantic Versioning 
 
 ## [Unreleased]
 
+- Added: `adb` module (`lib/adb.sh`) — multi-device-safe Android Debug Bridge helpers: `adb_available`, `adb_ready_serials`, `adb_device_ip`, `adb_device_model`, and an `adb_list_devices` SERIAL/MODEL/Wi-Fi-IP table. Uses `adb -s <serial>` so it works with more than one device attached.
 - Added: CI helper scripts for Node, Python, Flutter, Gradle, Go, and basic security checks.
 - Added: `scripts/pin_production.sh` to fast-forward the production branch to a release tag.
 - Added: `scripts/check_release_version.sh` to verify release versions before tagging or publishing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,5 +51,6 @@ Modules overview
 - package_publish — Debian package builds and PPA upload helpers.
 - packaging — packaging metadata helpers and template formatting.
 - ci_defaults — centralized Docker image version defaults for CI helper scripts.
+- adb — list/inspect USB-connected Android devices (serials, model, Wi-Fi IP); multi-device safe.
 
 If you add a new module or function, update ./docs/api.md and the relevant ./docs/modules/*.md file. See AGENTS.md for the process and checklist.

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,3 +24,4 @@ This index lists all modules and their functions. See the linked module pages fo
 - package_publish — ./modules/package_publish.md
 - packaging — ./modules/packaging.md
 - ci_defaults — ./modules/ci_defaults.md
+- adb — ./modules/adb.md

--- a/docs/modules/adb.md
+++ b/docs/modules/adb.md
@@ -1,0 +1,61 @@
+# adb
+
+Utilities for USB-connected Android devices via the Android Debug Bridge (`adb`).
+All helpers are **multi-device safe**: they target a device with `adb -s <serial>`
+rather than a bare `adb shell`, which errors with *more than one device* once a
+second device is attached. Every function returns non-zero / no-ops when `adb` is
+not installed, so callers degrade cleanly.
+
+Requirements
+------------
+
+- `adb` (Android platform-tools) on `PATH`. Without it the functions return
+  non-zero (and `adb_list_devices` logs a warning).
+
+Functions
+---------
+
+- adb_available
+  - Purpose: Check whether the `adb` CLI is available.
+  - Returns: 0 if `adb` is on `PATH`, non-zero otherwise.
+
+- adb_ready_serials
+  - Purpose: Print the serial of each *ready* device, one per line.
+  - Behavior: Skips the header line and any `offline`/`unauthorized` entries
+    (the device-state column must be exactly `device`).
+  - Returns: prints serials (possibly none); non-zero if `adb` is missing.
+
+- adb_device_ip serial [iface=wlan0]
+  - Purpose: Print a device's IPv4 address on an interface (default `wlan0` /
+    Wi-Fi). Pass e.g. `rmnet_data0` for a cellular interface.
+  - Returns: 0 and prints the IP; non-zero with no output when `adb` is missing,
+    the serial is empty, or the interface has no address (e.g. Wi-Fi off).
+
+- adb_device_model serial
+  - Purpose: Print `ro.product.model` for a device (CR/LF trimmed).
+  - Returns: non-zero with no output when `adb` is missing or the serial is empty.
+
+- adb_list_devices [iface=wlan0]
+  - Purpose: Print a `SERIAL  MODEL  IP` table for every ready device — useful for
+    finding a phone's IP to reach an on-device HTTP API.
+  - Behavior: Works with any number of devices attached. Shows
+    `<no wlan0 / Wi-Fi off>` when a device has no address on the interface.
+  - Returns: 1 when `adb` is missing; 0 (with an empty table) when no devices are
+    ready.
+
+Examples
+--------
+
+```bash
+source helpers.sh
+shlib_import adb
+
+# A table of every attached phone with its Wi-Fi IP.
+adb_list_devices
+
+# Script against a single device.
+for s in $(adb_ready_serials); do
+  ip="$(adb_device_ip "$s")" || continue
+  echo "$(adb_device_model "$s") is at $ip"
+done
+```

--- a/lib/adb.sh
+++ b/lib/adb.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# adb / Android device utilities
+#
+# Helpers for working with USB-connected Android devices via the Android Debug
+# Bridge (`adb`). All functions are multi-device safe — they target a specific
+# device with `adb -s <serial>` rather than a bare `adb shell`, which errors with
+# "more than one device" once a second device is attached. Every function is a
+# no-op / non-zero return when `adb` is missing, so callers can degrade cleanly.
+
+# Usage: adb_available; returns 0 if the adb CLI is on PATH.
+adb_available() {
+  command -v adb >/dev/null 2>&1
+}
+
+# Usage: adb_ready_serials; prints the serial of each *ready* device, one per
+# line, skipping the header and any offline/unauthorized entries (the state
+# column must be exactly "device"). Prints nothing when none are ready.
+adb_ready_serials() {
+  adb_available || return 1
+  adb devices 2>/dev/null | awk 'NR>1 && $2=="device"{print $1}'
+}
+
+# Usage: adb_device_ip <serial> [iface=wlan0]; prints the device's IPv4 address
+# on the interface (default wlan0 / Wi-Fi). Returns non-zero with no output when
+# adb is missing, the serial is empty, or the interface has no address (e.g.
+# Wi-Fi off). Pass e.g. "rmnet_data0" for a cellular interface.
+adb_device_ip() {
+  local serial="$1" iface="${2:-wlan0}" ip=""
+  adb_available || return 1
+  [[ -n "$serial" ]] || return 1
+  ip="$(adb -s "$serial" shell ip -f inet addr show "$iface" 2>/dev/null \
+        | grep -o 'inet [0-9.]*' | awk '{print $2}' | head -n1)"
+  [[ -n "$ip" ]] || return 1
+  printf '%s\n' "$ip"
+}
+
+# Usage: adb_device_model <serial>; prints ro.product.model (CR/LF trimmed).
+adb_device_model() {
+  local serial="$1"
+  adb_available || return 1
+  [[ -n "$serial" ]] || return 1
+  adb -s "$serial" shell getprop ro.product.model 2>/dev/null | tr -d '\r\n'
+}
+
+# Usage: adb_list_devices [iface=wlan0]; prints a "SERIAL  MODEL  IP" table for
+# every ready device. Works with any number of devices attached. Returns 1 when
+# adb is missing; 0 (and an empty table) when no devices are ready.
+adb_list_devices() {
+  local iface="${1:-wlan0}" s ip model
+  local -a serials=()
+  if ! adb_available; then
+    log_warn "adb not found. Install the Android platform-tools and put adb on PATH."
+    return 1
+  fi
+  mapfile -t serials < <(adb_ready_serials)
+  if [[ ${#serials[@]} -eq 0 ]]; then
+    log_warn "No ready devices. Check the USB cable and 'adb devices' — authorize the on-phone prompt if it shows 'unauthorized'."
+    return 0
+  fi
+  printf '%-22s %-22s %s\n' "SERIAL" "MODEL" "IP ($iface)"
+  for s in "${serials[@]}"; do
+    ip="$(adb_device_ip "$s" "$iface" || true)"
+    model="$(adb_device_model "$s" || true)"
+    printf '%-22s %-22s %s\n' "$s" "${model:-?}" "${ip:-<no $iface / Wi-Fi off>}"
+  done
+}


### PR DESCRIPTION
Adds a reusable **`adb`** module so any project can list/inspect USB-connected Android devices.

## Why
A bare `adb shell` errors with *more than one device* once a second device is attached. These helpers always use `adb -s <serial>`, so they work with any number of devices — handy for finding a phone's Wi-Fi IP to reach an on-device HTTP API.

## Adds — `lib/adb.sh`
- `adb_available` — is the `adb` CLI on PATH?
- `adb_ready_serials` — serials of ready devices (skips offline/unauthorized + header)
- `adb_device_ip <serial> [iface=wlan0]` — IPv4 on an interface (Wi-Fi by default)
- `adb_device_model <serial>` — `ro.product.model`
- `adb_list_devices [iface]` — a `SERIAL  MODEL  IP` table

All return non-zero / no-op when `adb` is missing, so callers degrade cleanly.

## Docs / checklist
- `docs/modules/adb.md` (new), `docs/api.md` + `docs/README.md` updated, `CHANGELOG.md` under `[Unreleased]`.
- `make examples` passes; `bash -n` clean; verified live against two attached phones (`adb_list_devices` printed both with their Wi-Fi IPs).

## Follow-up
The repo keeps Bash↔PowerShell parity (`ps/lib/*.ps1`). I deliberately did **not** ship an untested `ps/lib/adb.ps1` — happy to add the PowerShell counterpart + doc as a follow-up if you want parity.

Not merging — yours to merge.
