### PR TITLE
fix(ci): create GitHub Release via shared ci-helpers workflow (GITHUB_TOKEN tag-push doesn't trigger release.yml)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -97,6 +97,19 @@ jobs:
           echo "tag_created=true" >> "$GITHUB_OUTPUT"
           echo "tag_name=$tag" >> "$GITHUB_OUTPUT"
 
+      # GITHUB_TOKEN-pushed tags don't trigger release.yml's `on: push: tags`
+      # (GitHub anti-recursion), so create the Release in this job — same fix as
+      # release-tag.yml.
+      - name: Create GitHub Release
+        if: ${{ steps.push_tag.outputs.tag_created == 'true' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.push_tag.outputs.tag_name }}
+          name: Release ${{ steps.push_tag.outputs.tag_name }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Move production to new tag
         if: ${{ steps.push_tag.outputs.tag_created == 'true' && github.ref == 'refs/heads/main' }}
         shell: bash

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,6 +11,9 @@ jobs:
   auto-tag:
     if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
+    outputs:
+      tag_created: ${{ steps.push_tag.outputs.tag_created }}
+      tag_name: ${{ steps.push_tag.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,19 +100,6 @@ jobs:
           echo "tag_created=true" >> "$GITHUB_OUTPUT"
           echo "tag_name=$tag" >> "$GITHUB_OUTPUT"
 
-      # GITHUB_TOKEN-pushed tags don't trigger release.yml's `on: push: tags`
-      # (GitHub anti-recursion), so create the Release in this job — same fix as
-      # release-tag.yml.
-      - name: Create GitHub Release
-        if: ${{ steps.push_tag.outputs.tag_created == 'true' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.push_tag.outputs.tag_name }}
-          name: Release ${{ steps.push_tag.outputs.tag_name }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Move production to new tag
         if: ${{ steps.push_tag.outputs.tag_created == 'true' && github.ref == 'refs/heads/main' }}
         shell: bash
@@ -133,3 +123,14 @@ jobs:
         run: |
           echo "Tag ${{ steps.push_tag.outputs.tag_name }} was created, but workflow ref is '${GITHUB_REF}'."
           echo "Production pinning only runs when auto-tag is dispatched from 'main'."
+
+  # The tag is pushed with GITHUB_TOKEN, which doesn't trigger release.yml's
+  # tag-push event, so create the Release here via the shared ci-helpers workflow.
+  release:
+    needs: auto-tag
+    if: ${{ needs.auto-tag.outputs.tag_created == 'true' }}
+    permissions:
+      contents: write
+    uses: nikolareljin/ci-helpers/.github/workflows/create-github-release.yml@production
+    with:
+      release_tag: ${{ needs.auto-tag.outputs.tag_name }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    outputs:
+      tag_created: ${{ steps.tag_release.outputs.tag_created }}
+      tag_name: ${{ steps.tag_release.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,21 +49,6 @@ jobs:
           echo "tag_created=true" >> "$GITHUB_OUTPUT"
           echo "tag_name=$version" >> "$GITHUB_OUTPUT"
 
-      # The tag above is pushed with the workflow's GITHUB_TOKEN, and GitHub does
-      # NOT trigger other workflows (e.g. release.yml's `on: push: tags`) for refs
-      # created by GITHUB_TOKEN — that anti-recursion rule is why Releases stopped
-      # being created after 0.10.1. So create the GitHub Release right here, in the
-      # same job that made the tag, instead of relying on the tag-push event.
-      - name: Create GitHub Release
-        if: ${{ steps.tag_release.outputs.tag_created == 'true' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.tag_release.outputs.tag_name }}
-          name: Release ${{ steps.tag_release.outputs.tag_name }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Move production to new tag
         if: ${{ steps.tag_release.outputs.tag_created == 'true' }}
         shell: bash
@@ -77,3 +65,17 @@ jobs:
           fi
           git push origin production
           echo "production branch updated to tag ${tag}"
+
+  # The tag above is pushed with the workflow's GITHUB_TOKEN, and GitHub does NOT
+  # trigger other workflows (e.g. release.yml's `on: push: tags`) for refs created
+  # by GITHUB_TOKEN — that anti-recursion rule is why Releases stopped being
+  # created after 0.10.1. Create the Release here via the shared ci-helpers
+  # reusable workflow instead of relying on the suppressed tag-push event.
+  release:
+    needs: tag
+    if: ${{ needs.tag.outputs.tag_created == 'true' }}
+    permissions:
+      contents: write
+    uses: nikolareljin/ci-helpers/.github/workflows/create-github-release.yml@production
+    with:
+      release_tag: ${{ needs.tag.outputs.tag_name }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -46,6 +46,21 @@ jobs:
           echo "tag_created=true" >> "$GITHUB_OUTPUT"
           echo "tag_name=$version" >> "$GITHUB_OUTPUT"
 
+      # The tag above is pushed with the workflow's GITHUB_TOKEN, and GitHub does
+      # NOT trigger other workflows (e.g. release.yml's `on: push: tags`) for refs
+      # created by GITHUB_TOKEN — that anti-recursion rule is why Releases stopped
+      # being created after 0.10.1. So create the GitHub Release right here, in the
+      # same job that made the tag, instead of relying on the tag-push event.
+      - name: Create GitHub Release
+        if: ${{ steps.tag_release.outputs.tag_created == 'true' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag_release.outputs.tag_name }}
+          name: Release ${{ steps.tag_release.outputs.tag_name }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Move production to new tag
         if: ${{ steps.tag_release.outputs.tag_created == 'true' }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: Release on tag
 
+# Fallback for tags pushed MANUALLY (by a human / PAT), which do trigger this
+# `push: tags` event. Tags created by the automated GITHUB_TOKEN path are handled
+# in-run by release-tag.yml / auto-tag.yml instead (GITHUB_TOKEN-pushed refs don't
+# trigger downstream workflows). Both paths use the same shared ci-helpers workflow.
+
 on:
   push:
     tags:
@@ -10,22 +15,8 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Read version
-        id: ver
-        run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    uses: nikolareljin/ci-helpers/.github/workflows/create-github-release.yml@production
+    with:
+      release_tag: ${{ github.ref_name }}


### PR DESCRIPTION
## Problem
GitHub Releases stopped being created after **0.10.1** — tags `0.11.0`–`0.15.0` exist (and `production`/`VERSION` advance), but no Release object was made.

## Root cause
`release-tag.yml` (on push to `main`) / `auto-tag.yml` push the version tag using the workflow's **`GITHUB_TOKEN`**. GitHub deliberately **does not trigger other workflows for refs created by `GITHUB_TOKEN`** (anti-recursion), so `release.yml` (`on: push: tags`) never fired for those tags. Evidence: `release.yml` last ran for `0.10.1`; tag `0.14.0` was created by `github-actions[bot]`.

## Fix — use the shared ci-helpers workflow
Create the Release **in the same run** that makes the tag, via the org's reusable workflow **`nikolareljin/ci-helpers/.github/workflows/create-github-release.yml@production`** (validates the tag, extracts CHANGELOG notes for that version, falls back to auto-generated notes):

- **`release-tag.yml`** / **`auto-tag.yml`**: the tag job now exposes `tag_created` / `tag_name` as job outputs; a dependent `release` job calls the shared workflow with that tag. No dependency on the suppressed tag-push event.
- **`release.yml`**: the manual-tag-push fallback (human/PAT tags *do* trigger it) now also calls the same shared workflow — one consistent release path.

## Notes
- Tracks ci-helpers `@production` per the org convention. No new secrets (uses `GITHUB_TOKEN` + `contents: write`).
- All three workflows validated as YAML; no inlined `softprops` left in this repo.
- The 12 previously-missing Releases were already backfilled manually; this stops it recurring.

Not merging — yours to merge.
