### PR TITLE
Name iso-forge in the helper comments and module docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project uses Keep a Changelog style and aims to follow Semantic Versioning 
 
 ## [Unreleased]
 
+### Changed
+- Comments and module docs name `iso-forge` rather than `burn-iso`. The repository
+  those helpers were first written for was renamed; no behavior changed.
+
+
 ## 2026-08-22 — v0.23.0
 
 - Added: `lib/hub.sh`, corpus-hub setup for capture clients. Every client of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ This project uses Keep a Changelog style and aims to follow Semantic Versioning 
 ## [Unreleased]
 
 ### Changed
-- Comments and module docs name `iso-forge` rather than `burn-iso`. The repository
-  those helpers were first written for was renamed; no behavior changed.
+- Comments and module docs name `iso-forge` rather than `burn-iso`, following the
+  rename of the repository these helpers were first written for. No behavior changed.
 
 
 ## 2026-08-22 — v0.23.0

--- a/docs/modules/dialog.md
+++ b/docs/modules/dialog.md
@@ -16,12 +16,12 @@ Functions
   - Returns: 0 on success; non-zero (with error message) if canceled or empty.
 
 - select_multiple_distros
-  - Purpose: Checklist selection used by the burn-iso workflow.
+  - Purpose: Checklist selection used by the iso-forge workflow.
   - Requirements: Associative array `DISTROS` mapping name -> URL must be defined by the caller.
   - Returns: space-separated selected names.
 
 - select_distro
-  - Purpose: Menu selection used by the burn-iso workflow.
+  - Purpose: Menu selection used by the iso-forge workflow.
   - Requirements: `DISTROS` associative array.
   - Returns: selected name.
 

--- a/lib/dialog.sh
+++ b/lib/dialog.sh
@@ -52,7 +52,7 @@ get_value() {
   rm -f "$tmp"
 }
 
-# Selection helpers used by the iso-forge project. Expect an associative array DISTROS to be defined by the caller.
+# Selection helpers used by iso-forge. Expect an associative array DISTROS to be defined by the caller.
 select_multiple_distros() {
   dialog_init; check_if_dialog_installed || return 1
   local selected_distros options=() d

--- a/lib/dialog.sh
+++ b/lib/dialog.sh
@@ -52,7 +52,7 @@ get_value() {
   rm -f "$tmp"
 }
 
-# Selection helpers used by burn-iso project. Expect an associative array DISTROS to be defined by the caller.
+# Selection helpers used by the iso-forge project. Expect an associative array DISTROS to be defined by the caller.
 select_multiple_distros() {
   dialog_init; check_if_dialog_installed || return 1
   local selected_distros options=() d

--- a/lib/file.sh
+++ b/lib/file.sh
@@ -96,7 +96,7 @@ verify_checksum() {
   fi
 }
 
-# Convenience used by burn-iso: expects DISTROS associative array defined by caller
+# Convenience used by iso-forge: expects DISTROS associative array defined by caller
 download_iso() {
   local distro_name="$1"
   local url="${DISTROS[$distro_name]}"

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -89,7 +89,7 @@ log_debug() {
   return 0
 }
 
-# Compatibility wrapper for burn-iso `print` function
+# Compatibility wrapper for the iso-forge `print` function
 print() {
   local color="$1"; shift
   local message="$*"

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -89,7 +89,7 @@ log_debug() {
   return 0
 }
 
-# Compatibility wrapper for the iso-forge `print` function
+# Compatibility wrapper for iso-forge's `print` function
 print() {
   local color="$1"; shift
   local message="$*"


### PR DESCRIPTION
`nikolareljin/burn-iso` was renamed to `nikolareljin/iso-forge`. These helpers carry comments naming it as the project they were first written for:

- `lib/dialog.sh:55`, `lib/logging.sh:91`, `lib/file.sh:99`
- `docs/modules/dialog.md:19,24`

Comments and docs only, no behavior change. This is the canonical source; the ~19 vendored checkouts across the fleet pick it up on their next submodule bump, so none of them are edited by hand.