### PR TITLE
fix: keep the original script when install_dev_cli runs twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ This project uses Keep a Changelog style and aims to follow Semantic Versioning 
   for some other reason and the root file is a real script, the backup slot
   that would have saved it is already taken, so there is no move that does not
   lose a file -- the shim is skipped with a warning and both files are left
-  alone. Covered by `tests/install_dev_cli_test.sh`, whose cases fail on the
-  respective unfixed code.
+  alone. `rm`, `mv`, `cp` and `chmod` now also pass `--` before the path, so a
+  shim name that begins with a dash cannot be read as an option. Covered by
+  `tests/install_dev_cli_test.sh`, whose cases fail on the respective unfixed
+  code and which asserts the installer's exit status rather than discarding it.
 
 ## 2026-09-02 — v0.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ This project uses Keep a Changelog style and aims to follow Semantic Versioning 
   previous run wrote, so the move replaced the caller's original — the only
   copy of it — with our generated three-line shim. An existing
   `.pre-dev-cli` backup is now kept and the current file removed instead.
-  Covered by `tests/install_dev_cli_test.sh`, which fails on the old code.
+
+  That removal is guarded: only a shim this script wrote is discarded, matched
+  on its `# Compatibility shim. Use ./dev ...` marker. If `.pre-dev-cli` exists
+  for some other reason and the root file is a real script, the backup slot
+  that would have saved it is already taken, so there is no move that does not
+  lose a file -- the shim is skipped with a warning and both files are left
+  alone. Covered by `tests/install_dev_cli_test.sh`, whose cases fail on the
+  respective unfixed code.
 
 ## 2026-09-02 — v0.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project uses Keep a Changelog style and aims to follow Semantic Versioning 
 
 ## [Unreleased]
 
+### Fixed
+- `scripts/install_dev_cli.sh` no longer destroys the original script when
+  `--shims` is run twice. The backup was an unconditional
+  `mv "$dest" "$dest.pre-dev-cli"`, but on a second run `$dest` is the shim the
+  previous run wrote, so the move replaced the caller's original — the only
+  copy of it — with our generated three-line shim. An existing
+  `.pre-dev-cli` backup is now kept and the current file removed instead.
+  Covered by `tests/install_dev_cli_test.sh`, which fails on the old code.
+
 ## 2026-09-02 — v0.24.0
 
 ### Added

--- a/scripts/install_dev_cli.sh
+++ b/scripts/install_dev_cli.sh
@@ -109,8 +109,16 @@ if [[ -n "$SHIMS" ]]; then
       # existing backup would replace the caller's original script with our
       # own generated one -- the only copy of it, gone. Keep the first backup.
       if [[ -e "$dest.pre-dev-cli" ]]; then
-        say "keep backup: $name.pre-dev-cli already exists"
-        [[ "$DRY_RUN" == "true" ]] || rm -f "$dest"
+        # Only a shim we wrote is safe to discard. If $dest is anything else
+        # the backup slot that would have saved it is already occupied, so
+        # there is no move that does not lose a file: leave both untouched.
+        if grep -q '^# Compatibility shim\. Use \./dev ' "$dest" 2>/dev/null; then
+          say "keep backup: $name.pre-dev-cli already exists"
+          [[ "$DRY_RUN" == "true" ]] || rm -f "$dest"
+        else
+          log_warn "skip $name: $name.pre-dev-cli exists and ./$name is not a shim we wrote"
+          continue
+        fi
       else
         say "back up: $name -> $name.pre-dev-cli"
         [[ "$DRY_RUN" == "true" ]] || mv "$dest" "$dest.pre-dev-cli"

--- a/scripts/install_dev_cli.sh
+++ b/scripts/install_dev_cli.sh
@@ -105,8 +105,16 @@ if [[ -n "$SHIMS" ]]; then
     [[ -n "$name" ]] || continue
     dest="$REPO/$name"
     if [[ -e "$dest" && "$FORCE" == "false" ]]; then
-      say "back up: $name -> $name.pre-dev-cli"
-      [[ "$DRY_RUN" == "true" ]] || mv "$dest" "$dest.pre-dev-cli"
+      # On a re-run $dest is the shim written last time. Moving that over an
+      # existing backup would replace the caller's original script with our
+      # own generated one -- the only copy of it, gone. Keep the first backup.
+      if [[ -e "$dest.pre-dev-cli" ]]; then
+        say "keep backup: $name.pre-dev-cli already exists"
+        [[ "$DRY_RUN" == "true" ]] || rm -f "$dest"
+      else
+        say "back up: $name -> $name.pre-dev-cli"
+        [[ "$DRY_RUN" == "true" ]] || mv "$dest" "$dest.pre-dev-cli"
+      fi
     fi
     say "shim: ./$name -> ./dev $name"
     [[ "$DRY_RUN" == "true" ]] && continue

--- a/scripts/install_dev_cli.sh
+++ b/scripts/install_dev_cli.sh
@@ -73,8 +73,8 @@ install_file() {
   say "write: $rel"
   [[ "$DRY_RUN" == "true" ]] && return 0
   mkdir -p "$(dirname "$dest")"
-  cp "$src" "$dest"
-  chmod "$mode" "$dest"
+  cp -- "$src" "$dest"
+  chmod "$mode" -- "$dest"
 }
 
 # --- the entry point -------------------------------------------------------
@@ -114,14 +114,14 @@ if [[ -n "$SHIMS" ]]; then
         # there is no move that does not lose a file: leave both untouched.
         if grep -q '^# Compatibility shim\. Use \./dev ' "$dest" 2>/dev/null; then
           say "keep backup: $name.pre-dev-cli already exists"
-          [[ "$DRY_RUN" == "true" ]] || rm -f "$dest"
+          [[ "$DRY_RUN" == "true" ]] || rm -f -- "$dest"
         else
           log_warn "skip $name: $name.pre-dev-cli exists and ./$name is not a shim we wrote"
           continue
         fi
       else
         say "back up: $name -> $name.pre-dev-cli"
-        [[ "$DRY_RUN" == "true" ]] || mv "$dest" "$dest.pre-dev-cli"
+        [[ "$DRY_RUN" == "true" ]] || mv -- "$dest" "$dest.pre-dev-cli"
       fi
     fi
     say "shim: ./$name -> ./dev $name"
@@ -131,7 +131,7 @@ if [[ -n "$SHIMS" ]]; then
 # Compatibility shim. Use ./dev $name — this is removed one minor version on.
 exec bash "\$(dirname "\$0")/scripts/cli.sh" $name "\$@"
 EOF
-    chmod 755 "$dest"
+    chmod 755 -- "$dest"
   done
 fi
 

--- a/tests/install_dev_cli_test.sh
+++ b/tests/install_dev_cli_test.sh
@@ -25,13 +25,27 @@ make_repo() {
   chmod +x "$dir/start"
 }
 
+# Run the installer and fail the test if it exits non-zero. Discarding the
+# status would let a hard error pass unnoticed whenever the file assertions
+# happened to hold anyway.
+run_installer() {
+  local label="$1"; shift
+  local rc=0
+  bash scripts/install_dev_cli.sh "$@" >/dev/null 2>&1 || rc=$?
+  if [[ $rc -eq 0 ]]; then
+    note "$label: installer exited 0"
+  else
+    error "$label: installer exited $rc"
+  fi
+}
+
 tmp_root="$(mktemp -d)"
 trap 'rm -rf "$tmp_root"' EXIT
 
 # 1) First install backs the original up and leaves a shim behind.
 repo="$tmp_root/once"
 make_repo "$repo"
-bash scripts/install_dev_cli.sh --repo "$repo" --shims start >/dev/null 2>&1 || true
+run_installer "first install" --repo "$repo" --shims start
 
 if grep -q "$ORIGINAL" "$repo/start.pre-dev-cli" 2>/dev/null; then
   note "first run backs the original up to start.pre-dev-cli"
@@ -47,7 +61,7 @@ fi
 # 2) Re-running must not overwrite that backup with the shim it just wrote.
 #    Regression: `mv "$dest" "$dest.pre-dev-cli"` ran unconditionally, so a
 #    second install replaced the only copy of the caller's script.
-bash scripts/install_dev_cli.sh --repo "$repo" --shims start >/dev/null 2>&1 || true
+run_installer "re-install" --repo "$repo" --shims start
 
 if grep -q "$ORIGINAL" "$repo/start.pre-dev-cli" 2>/dev/null; then
   note "second run preserves the original backup"
@@ -66,7 +80,7 @@ fi
 guard="$tmp_root/guard"
 make_repo "$guard"
 printf '#!/usr/bin/env bash\necho "unrelated pre-existing backup"\n' > "$guard/start.pre-dev-cli"
-bash scripts/install_dev_cli.sh --repo "$guard" --shims start >/dev/null 2>&1 || true
+run_installer "foreign backup" --repo "$guard" --shims start
 
 if grep -q "$ORIGINAL" "$guard/start" 2>/dev/null; then
   note "a real script is left intact when a foreign .pre-dev-cli exists"
@@ -82,7 +96,7 @@ fi
 # 4) --dry-run must not touch anything.
 dry="$tmp_root/dry"
 make_repo "$dry"
-bash scripts/install_dev_cli.sh --repo "$dry" --shims start --dry-run >/dev/null 2>&1 || true
+run_installer "dry run" --repo "$dry" --shims start --dry-run
 
 if [[ ! -e "$dry/start.pre-dev-cli" ]] && grep -q "$ORIGINAL" "$dry/start"; then
   note "--dry-run leaves the tree untouched"

--- a/tests/install_dev_cli_test.sh
+++ b/tests/install_dev_cli_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SCRIPT: install_dev_cli_test.sh
+# DESCRIPTION: Smoke tests for scripts/install_dev_cli.sh shim backup behaviour.
+# USAGE: ./tests/install_dev_cli_test.sh
+# PARAMETERS: No required parameters.
+# EXAMPLE: bash tests/install_dev_cli_test.sh
+# ----------------------------------------------------
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+cd "$root_dir"
+
+failures=0
+note()  { echo "[install_dev_cli_test] $*"; }
+error() { echo "[install_dev_cli_test][ERROR] $*" >&2; failures=$((failures+1)); }
+
+ORIGINAL='echo "original script"'
+
+# A throwaway git repo with one root script to shim.
+make_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q .
+  printf '#!/usr/bin/env bash\n%s\n' "$ORIGINAL" > "$dir/start"
+  chmod +x "$dir/start"
+}
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+# 1) First install backs the original up and leaves a shim behind.
+repo="$tmp_root/once"
+make_repo "$repo"
+bash scripts/install_dev_cli.sh --repo "$repo" --shims start >/dev/null 2>&1 || true
+
+if grep -q "$ORIGINAL" "$repo/start.pre-dev-cli" 2>/dev/null; then
+  note "first run backs the original up to start.pre-dev-cli"
+else
+  error "first run did not preserve the original in start.pre-dev-cli"
+fi
+if grep -q 'cli.sh' "$repo/start" 2>/dev/null; then
+  note "first run installs the shim"
+else
+  error "first run did not install the shim"
+fi
+
+# 2) Re-running must not overwrite that backup with the shim it just wrote.
+#    Regression: `mv "$dest" "$dest.pre-dev-cli"` ran unconditionally, so a
+#    second install replaced the only copy of the caller's script.
+bash scripts/install_dev_cli.sh --repo "$repo" --shims start >/dev/null 2>&1 || true
+
+if grep -q "$ORIGINAL" "$repo/start.pre-dev-cli" 2>/dev/null; then
+  note "second run preserves the original backup"
+else
+  error "second run destroyed the original backup (it now holds the shim)"
+fi
+if grep -q 'cli.sh' "$repo/start" 2>/dev/null; then
+  note "second run leaves the shim in place"
+else
+  error "second run did not leave a shim at start"
+fi
+
+# 3) --dry-run must not touch anything.
+dry="$tmp_root/dry"
+make_repo "$dry"
+bash scripts/install_dev_cli.sh --repo "$dry" --shims start --dry-run >/dev/null 2>&1 || true
+
+if [[ ! -e "$dry/start.pre-dev-cli" ]] && grep -q "$ORIGINAL" "$dry/start"; then
+  note "--dry-run leaves the tree untouched"
+else
+  error "--dry-run modified the tree"
+fi
+
+if [[ $failures -gt 0 ]]; then
+  echo "[install_dev_cli_test] FAILED ($failures)" >&2
+  exit 1
+fi
+echo "[install_dev_cli_test] all checks passed"

--- a/tests/install_dev_cli_test.sh
+++ b/tests/install_dev_cli_test.sh
@@ -60,7 +60,26 @@ else
   error "second run did not leave a shim at start"
 fi
 
-# 3) --dry-run must not touch anything.
+# 3) A pre-existing .pre-dev-cli next to a file we did not write must not be
+#    treated as our own shim. Deleting $dest there would destroy a real script
+#    while its backup slot is already occupied -- nothing may be touched.
+guard="$tmp_root/guard"
+make_repo "$guard"
+printf '#!/usr/bin/env bash\necho "unrelated pre-existing backup"\n' > "$guard/start.pre-dev-cli"
+bash scripts/install_dev_cli.sh --repo "$guard" --shims start >/dev/null 2>&1 || true
+
+if grep -q "$ORIGINAL" "$guard/start" 2>/dev/null; then
+  note "a real script is left intact when a foreign .pre-dev-cli exists"
+else
+  error "the real script at start was destroyed when a foreign .pre-dev-cli existed"
+fi
+if grep -q 'unrelated pre-existing backup' "$guard/start.pre-dev-cli" 2>/dev/null; then
+  note "the foreign .pre-dev-cli is left intact"
+else
+  error "the foreign .pre-dev-cli was overwritten"
+fi
+
+# 4) --dry-run must not touch anything.
 dry="$tmp_root/dry"
 make_repo "$dry"
 bash scripts/install_dev_cli.sh --repo "$dry" --shims start --dry-run >/dev/null 2>&1 || true


### PR DESCRIPTION
Surfaced by a Copilot review on ci-helpers#156, which vendors this release. Confirmed with a working reproduction.

## The bug

`scripts/install_dev_cli.sh` backed up a shimmed script unconditionally:

```bash
if [[ -e "$dest" && "$FORCE" == "false" ]]; then
  say "back up: $name -> $name.pre-dev-cli"
  mv "$dest" "$dest.pre-dev-cli"
fi
```

On a **second run** `$dest` is the shim the *previous* run wrote. The `mv` therefore moves that shim over the existing backup, replacing the caller's original script — the only copy of it — with our generated three lines. The loss is silent and unrecoverable.

### Reproduction (before the fix)

```
before:       echo "ORIGINAL USER SCRIPT - irreplaceable"
run 1 backup: echo "ORIGINAL USER SCRIPT - irreplaceable"
run 2 backup: exec bash "$(dirname "$0")/scripts/cli.sh" start "$@"
>>> ORIGINAL LOST? YES - DESTROYED
```

## The fix

Keep the first backup; drop the current file instead. Re-running becomes idempotent rather than destructive.

```bash
if [[ -e "$dest.pre-dev-cli" ]]; then
  say "keep backup: $name.pre-dev-cli already exists"
  [[ "$DRY_RUN" == "true" ]] || rm -f "$dest"
else
  say "back up: $name -> $name.pre-dev-cli"
  [[ "$DRY_RUN" == "true" ]] || mv "$dest" "$dest.pre-dev-cli"
fi
```

## Tests

New `tests/install_dev_cli_test.sh` covers the first install, the destructive re-run, and `--dry-run`.

It was checked against the pre-fix code first — it fails there with `second run destroyed the original backup (it now holds the shim)`, exit 1 — and passes after. A test that cannot fail proves nothing, so that ordering matters here.

| Gate | Result |
|---|---|
| `make test` (14 test files) | **exit 0** |
| `shellcheck -S warning` on both changed scripts | clean |
| `changelog_check_header CHANGELOG.md` | exit 0 |

## Branch choice

Deliberately a `fix/` branch off `main`, **not** a release branch: PR #57 (`release/0.25.0`) is open and flagged do-not-merge, and I did not want to add a competing release line or disturb it. The defect is present on both `production` (0.24.0) and `release/0.25.0`, so it needs folding into whichever release ships next — your call which.

Not merged, not tagged, `create_production.sh` not run.
